### PR TITLE
Consolidate invite view CRCs

### DIFF
--- a/doc/CRC/invitationView.md
+++ b/doc/CRC/invitationView.md
@@ -1,8 +1,0 @@
-# InvitationView
-## responsibility
-- Show that a user has been accepted to an event
-- Allow them to accept or reject the invitation
-## collaborators
-- User
-- Invitation
-- InvitationController

--- a/doc/CRC/inviteFragment.md
+++ b/doc/CRC/inviteFragment.md
@@ -7,4 +7,7 @@
 - Display an accept and reject button
 ## collaborators
 - InvitationController
+- Invitation
+- User
+- Event
 - MainActivity


### PR DESCRIPTION
We had both an inviteView and inviteFragment CRC cards, which seemed to have the same responsibility. Therefore, I have removed inviteView and consolidated what was in it into inviteFragment.